### PR TITLE
Always use ChronologicTest to avoid destroying a real database.  :/

### DIFF
--- a/benchmark/publish.rb
+++ b/benchmark/publish.rb
@@ -30,7 +30,7 @@ end
 friends = 50
 events = 1000
 timeline = "cl_timeline"
-Chronologic.connection = Cassandra.new("Chronologic")
+Chronologic.connection = Cassandra.new("ChronologicTest")
 
 if __FILE__ == $PROGRAM_NAME
   result = Benchmark.measure do

--- a/benchmark/timeline.rb
+++ b/benchmark/timeline.rb
@@ -13,8 +13,8 @@ servers = [
 ]
 
 Chronologic.connection = Cassandra.new(
-  "Chronologic", 
-  servers, 
+  "ChronologicTest",
+  servers,
   :retries => 3
 )
 # logger = Logger.new(STDOUT)

--- a/benchmark/update_event.rb
+++ b/benchmark/update_event.rb
@@ -3,7 +3,7 @@ require "benchmark"
 require "logger"
 require "chronologic"
 
-Chronologic.connection = Cassandra.new("Chronologic")
+Chronologic.connection = Cassandra.new("ChronologicTest")
 
 # logger = Logger.new(STDOUT)
 # logger.level = Logger::DEBUG

--- a/examples/paginate.rb
+++ b/examples/paginate.rb
@@ -1,7 +1,7 @@
 require "pp"
 require "chronologic"
 
-Chronologic.connection = Cassandra.new("Chronologic")
+Chronologic.connection = Cassandra.new("ChronologicTest")
 
 puts "Paginating with Chronologic::Schema"
 page = Chronologic::Schema.timeline_for("user_1165", :per_page => 5).keys

--- a/spec/functional/model_spec.rb
+++ b/spec/functional/model_spec.rb
@@ -4,7 +4,7 @@ require 'story'
 describe 'Client-side models' do
 
   before { Chronologic::Client::Connection.instance = Chronologic::Client::Connection.new('http://localhost:9292') }
-  before { Chronologic.connection = Cassandra.new('Chronologic') }
+  before { Chronologic.connection = Cassandra.new('ChronologicTest') }
 
   let(:story) do
     Story.new.tap do |story|

--- a/spec/functional_helper.rb
+++ b/spec/functional_helper.rb
@@ -5,7 +5,7 @@ require 'helpers'
 module FunctionalTestHelpers
 
   def self.truncate_cfs
-    c = Cassandra.new("Chronologic")
+    c = Cassandra.new("ChronologicTest")
     [:Object, :Subscription, :Timeline, :Event].each do |cf|
       c.truncate!(cf)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,14 +22,14 @@ RSpec.configure do |config|
       clean_up_keyspace!(Chronologic.connection)
     else
       schema = {
-        'Chronologic' => {
+        'ChronologicTest' => {
           'Object' => {},
           'Subscription' => {},
           'Event' => {},
           'Timeline' => {}
         }
       }
-      Chronologic.connection = Cassandra::Mock.new('Chronologic', schema)
+      Chronologic.connection = Cassandra::Mock.new('ChronologicTest', schema)
     end
   end
 


### PR DESCRIPTION
Change the keyspace to ChronologicTest to avoid accidentally destroying a valid development Chronologic database.

@therealadam - Any problem with doing this?  
