### PR TITLE
Don't lock hashie at a version

### DIFF
--- a/chronologic.gemspec
+++ b/chronologic.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('cassandra', ["0.11.3"])
   s.add_dependency('httparty', ["~> 0.6.1"])
-  s.add_dependency('hashie', ["~> 0.4.0"])
+  s.add_dependency('hashie', ["> 0.4.0"])
   s.add_dependency('will_paginate', ["~> 3.0.pre2"])
   s.add_dependency('yajl-ruby', ["~> 0.7.7"])
   s.add_dependency('activesupport', ["~> 3.0.0"])


### PR DESCRIPTION
Allow the client to pick the version of hashie they want to use, setting the minimum allowable.
